### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/Tests/MakoIoT.Device.Services.Logging.Test/MakoIoT.Device.Services.Logging.Test.nfproj
+++ b/Tests/MakoIoT.Device.Services.Logging.Test/MakoIoT.Device.Services.Logging.Test.nfproj
@@ -38,11 +38,11 @@
     <Reference Include="nanoFramework.DependencyInjection">
       <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.11\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.TestFramework, Version=3.0.44.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.44\lib\nanoFramework.TestFramework.dll</HintPath>
+    <Reference Include="nanoFramework.TestFramework, Version=3.0.47.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.47\lib\nanoFramework.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.44\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.47\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/MakoIoT.Device.Services.Logging.Test/packages.config
+++ b/Tests/MakoIoT.Device.Services.Logging.Test/packages.config
@@ -3,5 +3,5 @@
   <package id="MakoIoT.Device.Services.Interface" version="1.0.47.44904" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
   <package id="nanoFramework.DependencyInjection" version="1.1.11" targetFramework="netnano1.0" />
-  <package id="nanoFramework.TestFramework" version="3.0.44" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="nanoFramework.TestFramework" version="3.0.47" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.TestFramework from 3.0.44 to 3.0.47</br>
[version update]

### :warning: This is an automated update. :warning:
