### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.Logging.nuspec
+++ b/MakoIoT.Device.Services.Logging.nuspec
@@ -21,7 +21,7 @@
       <dependency id="nanoFramework.System.Collections" version="1.5.67" />
       <dependency id="nanoFramework.System.Text" version="1.3.42" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.54.39044" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.55.11594" />
     </dependencies>
   </metadata>
   <files>

--- a/Tests/MakoIoT.Device.Services.Logging.Test/MakoIoT.Device.Services.Logging.Test.nfproj
+++ b/Tests/MakoIoT.Device.Services.Logging.Test/MakoIoT.Device.Services.Logging.Test.nfproj
@@ -30,7 +30,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.54.39044\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.55.11594\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib, Version=1.17.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>

--- a/Tests/MakoIoT.Device.Services.Logging.Test/packages.config
+++ b/Tests/MakoIoT.Device.Services.Logging.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.54.39044" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.55.11594" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnanoframework10" />
   <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.TestFramework" version="3.0.75" targetFramework="netnano1.0" developmentDependency="true" />

--- a/src/MakoIoT.Device.Services.Logging/MakoIoT.Device.Services.Logging.nfproj
+++ b/src/MakoIoT.Device.Services.Logging/MakoIoT.Device.Services.Logging.nfproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.54.39044\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.55.11594\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib, Version=1.17.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>

--- a/src/MakoIoT.Device.Services.Logging/packages.config
+++ b/src/MakoIoT.Device.Services.Logging/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.54.39044" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.55.11594" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnanoframework10" />
   <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.67" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Interface from 1.0.54.39044 to 1.0.55.11594</br>
[version update]

### :warning: This is an automated update. :warning:
